### PR TITLE
fixing FARM OS link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ FarmData2 is both a _second_ edition of it predecessor, FarmData, and the integr
 
 ### Acknowledgements ###
 
-FarmData2 is powered by the [farmOS](https://not.the.right.link2) open source project.
+FarmData2 is powered by the [farmOS](https://farmos.org/) open source project.
 
-Support and assistance with FarmData2 development has been received from [The Non-Profit FOSS Institute](https://npfi.org/).
+Support and assistance with FarmData2 development has been recegitived from [The Non-Profit FOSS Institute](https://npfi.org/).
 
 The development of FarmData2 has received partial support from:
 * The [GNOME Community Engagement Challenge](https://not.the.right.link3):


### PR DESCRIPTION
fixed the link for FARM.OS


---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
